### PR TITLE
On IE9, utf-8 url query parameters aren't encoded

### DIFF
--- a/portal.js
+++ b/portal.js
@@ -44,7 +44,7 @@
 		getAbsoluteURL: function(url) {
 			var div = document.createElement("div");
 			div.innerHTML = '<a href="' + url + '"/>';
-			return decodeURI(div.firstChild.href);
+			return encodeURI(decodeURI(div.firstChild.href));
 		},
 		iterate: function(fn) {
 			var timeoutId;


### PR DESCRIPTION
On IE9, utf-8 url query parameters aren't encoded and server get unknown characters : http://jsfiddle.net/p53eE/
