### PR TITLE
Update portal.js

### DIFF
--- a/portal.js
+++ b/portal.js
@@ -1332,7 +1332,7 @@
 						socket.data("event", event).fire("open");
 					};
 					ws.onmessage = function(event) {
-						socket.data("event", event)._fire(event.data);
+						socket.data("event", event)._fire("message", event.data);
 					};
 					ws.onerror = function(event) {
 						socket.data("event", event).fire("close", aborted ? "aborted" : "error");


### PR DESCRIPTION
Added a 1-st (omitted) string argument (event name) for the message callback (line 1335). Without the event name argument the method "_fire" searched the events dictionary for an incorrect event, found none, and "message" callback was never called.
